### PR TITLE
add: ブックマーク詳細ページ作成 #36

### DIFF
--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,6 +1,6 @@
 <div class="mt-4 relative">
   <% if @bookmarks.present? %>
-    <div class="flex flex-wrap">
+    <div class="flex flex-wrap z-40 absolute">
       <%= render @bookmarks %>
     </div>
   <% else %>
@@ -8,13 +8,13 @@
   <% end %>
   <div class="absolute top-40">
     <div class="flex flex-col">
-      <div class="h-40">
+      <div class="h-40 z-0">
         <%= image_tag 'woodframe03.jpg' %>
       </div>
-      <div class="h-40">
+      <div class="h-40 z-0">
         <%= image_tag 'woodframe03.jpg' %>
       </div>
-      <div class="h-40">
+      <div class="h-40 z-0">
         <%= image_tag 'woodframe03.jpg' %>
       </div>
     </div>

--- a/app/views/bookmarks/show.html.erb
+++ b/app/views/bookmarks/show.html.erb
@@ -1,2 +1,10 @@
-<h1>Bookmarks#show</h1>
-<p>Find me in app/views/bookmarks/show.html.erb</p>
+<div class="card w-1/3 bg-base-100 shadow-xl mx-auto mt-20 max-h-full">
+  <div class="card-body">
+    <h2 class="card-title"><%= @bookmark.title %></h2>
+    <%= link_to @bookmark.url, @bookmark.url, class:'link link-primary', target: '_blank' %>
+    <p><%= @bookmark.memo %></p>
+    <div class="card-actions justify-end">
+      <button class="btn btn-primary">Buy Now</button>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## 変更の概要
ブックマーク詳細ページの追加
ブックマーク一覧ページのブックマークが二段目からリンクが押せない状態だったので修正

## やったこと
本棚のフレームをabsoluteで配置したため、リンクが背面になりz-indexを指定しても整列出来なかったため、
ブックマークリンクにもabsoluteを追加

## 備考
ブクマ検索フォームがabsoluteの要素の背面になっているのは
後からフッターに加える予定