### PR TITLE
fix: ヘッダーメニューの修正、他軽微な修正

### DIFF
--- a/app/views/bookmarks/new.html.erb
+++ b/app/views/bookmarks/new.html.erb
@@ -1,3 +1,7 @@
+<div class="ml-6 mt-3">
+  <% breadcrumb :create_bookmark, @bookmark %>
+  <%= breadcrumbs separator: " &rsaquo; ", class:'text-neutral font-mplus' %>
+</div>
 <div class="container mx-auto w-1/3 my-28">
   <h1><%= t'.title' %></h1>
   <%= render "form", bookmark: @bookmark %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,12 +4,18 @@
   </div>
   <% if logged_in? %>
     <div class="flex-none gap-2">
+      <div class="tooltip tooltip-bottom tooltip-secondary" data-tip="<%= t('bookmarks.new.title') %>">
+        <button class="btn btn-ghost">
+          <%= link_to new_bookmark_path do %>
+            <i class="fa-regular fa-square-plus fa-lg"></i>
+          <% end %>
+        </button>
+      </div>
       <div class="dropdown dropdown-end">
         <div tabindex="0" role="button" class="btn btn-ghost avatar">
           <i class="fa-solid fa-bars fa-2x"></i>
         </div>
           <ul tabindex="0" class="absolute z-50 mt-3 p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-52">
-            <li><%= link_to t('bookmarks.new.title'), new_bookmark_path %></li>
             <li><%= button_to t('defaults.logout'), :logout, method: :delete %></li>
           </ul>
       </div>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -11,3 +11,8 @@
     link "ブックマーク編集"
     parent :bookmark, bookmark
   end
+
+  crumb :create_bookmark do |bookmark|
+    link "ブックマーク登録"
+    parent :bookmarks
+  end


### PR DESCRIPTION
## 変更の概要
ヘッダーのブックマーク登録ボタンをハンバーガーメニューの外に配置
パンくずをブックマーク登録画面にも追加


## なぜこの変更をするのか
利便性向上