### PR TITLE
fix: bookmarkのurlのバリデーション修正 #68

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,7 +1,7 @@
 class Bookmark < ApplicationRecord
   belongs_to :user
 
-  validates :url, presence: true
+  validates :url, presence: true, format: /\A#{URI::regexp(%w(http https))}\z/
   validates :title, length: { maximum: 255 }
   validates :memo, length: { maximum: 65535 }
 


### PR DESCRIPTION
## 変更の概要
URLにURL以外の文字列も登録できる状態を修正