### PR TITLE
fix:ブックマーク一覧の表示が崩れていた問題を修正

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -21,7 +21,7 @@ class BookmarksController < ApplicationController
 
   def update
     if @bookmark.update(bookmark_params)
-      redirect_to bookmarks_path, success: t('defaults.messages.update')
+      redirect_to bookmark_path, success: t('defaults.messages.update')
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/views/bookmarks/_detail.html.erb
+++ b/app/views/bookmarks/_detail.html.erb
@@ -1,10 +1,11 @@
 <div class="card w-52 h-32 bg-base-100 shadow-xl mr-4">
   <div class="card-body h-32 p-3">
-    <p><%= bookmark.title.truncate(24) %></p>
+    <p class="hover:text-primary"><%= bookmark.title.truncate(24) %></p>
     <%= link_to bookmark.url, target: '_blank' do %>
       <p class="text-xs link hover:link-secondary">
-      <%= bookmark.url.truncate(24) %><i class="fa-solid fa-earth-asia"></i>
+      <%= bookmark.url.truncate(24) %>
       </p>
       <% end %>
+      <p class="text-xs"><%= bookmark.memo.truncate(20) %></p>
   </div>
 </div>

--- a/app/views/bookmarks/_form.html.erb
+++ b/app/views/bookmarks/_form.html.erb
@@ -34,7 +34,7 @@
   <div class="form-group">
     <%= form.label CoverImage.model_name.human, class: 'text-neutral' %>
       <div class="flex flex-row flex-wrap">
-        <%= form.collection_radio_buttons(:cover_image_id, CoverImage.all, :id , :image, { checked: CoverImage.first.id }) do |b| %>
+        <%= form.collection_radio_buttons(:cover_image_id, CoverImage.all, :id , :image) do |b| %>
           <div class="mx-2">
             <%= b.radio_button %>
             <%= b.label{ image_tag b.text.url, class: 'max-w-20 h-28' } %>

--- a/app/views/bookmarks/_search_form.html.erb
+++ b/app/views/bookmarks/_search_form.html.erb
@@ -2,3 +2,6 @@
     <%= f.search_field :title_or_memo_cont, placeholder: t('defaults.bookmark_search'), class: 'input input-sm input-bordered w-80 max-w-full' %>
     <%= f.submit t('defaults.search'), class: 'btn btn-primary btn-sm' %>
 <% end %>
+<% if request.url.include?("commit") %>
+  <%= link_to t('defaults.return_bookmarks'), bookmarks_path, class: 'btn btn-sm btn-secondary'%>
+<% end %>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,20 +1,23 @@
-<div class="mt-4 relative h-4/5 overflow-auto">
+<div class="mt-4 relative h-4/5 overflow-auto min-h-screen">
   <% if @bookmarks.present? %>
-    <div class="flex flex-wrap flex-row mx-4">
+    <div class="flex flex-wrap flex-row mx-4 z-30 absolute">
       <%= render @bookmarks %>
     </div>
   <% else %>
     <p class="text-secondary"><%= t('.no_result') %></p>
   <% end %>
-  <div>
+  <div class="z-0 mt-40">
     <div class="flex flex-col">
       <div class="h-40">
         <%= image_tag 'woodframe03.jpg' %>
       </div>
-      <div class="h-40 z-0">
+      <div class="h-40">
         <%= image_tag 'woodframe03.jpg' %>
       </div>
-      <div class="h-40 z-0">
+      <div class="h-40">
+        <%= image_tag 'woodframe03.jpg' %>
+      </div>
+      <div class="h-40">
         <%= image_tag 'woodframe03.jpg' %>
       </div>
     </div>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,14 +1,14 @@
 <div class="mt-4 relative h-4/5 overflow-auto">
   <% if @bookmarks.present? %>
-    <div class="flex flex-wrap flex-row absolute z-20 mx-4">
+    <div class="flex flex-wrap flex-row mx-4">
       <%= render @bookmarks %>
     </div>
   <% else %>
     <p class="text-secondary"><%= t('.no_result') %></p>
   <% end %>
-  <div class="absolute top-40">
+  <div>
     <div class="flex flex-col">
-      <div class="h-40 z-0">
+      <div class="h-40">
         <%= image_tag 'woodframe03.jpg' %>
       </div>
       <div class="h-40 z-0">

--- a/app/views/bookmarks/show.html.erb
+++ b/app/views/bookmarks/show.html.erb
@@ -8,9 +8,9 @@
       <h2 class="card-title"><%= @bookmark.title %></h2>
       <%= render 'crud_menus' %>
     </div>
-    <div class="flex flex-row">
+    <div class="flex flex-row flex-wrap">
       <% @bookmark.tags.each do |tag| %>
-        <div class="badge badge-info mr-2">
+        <div class="badge badge-info mr-2 mb-1">
           <%= tag.name %>
         </div>
       <% end %>

--- a/app/views/bookmarks/show.html.erb
+++ b/app/views/bookmarks/show.html.erb
@@ -15,7 +15,7 @@
         </div>
       <% end %>
     </div>
-    <%= link_to @bookmark.url, @bookmark.url, class:'link link-primary', target: '_blank' %>
+    <%= link_to @bookmark.url, @bookmark.url, class:'link link-secondary', target: '_blank' %>
     <p><%= @bookmark.memo %></p>
   </div>
 </div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  config.default_per_page = 90
+  config.default_per_page = 80
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -11,6 +11,7 @@ ja:
     contact: 'お問い合わせ'
     cancel: 'キャンセル'
     password_reset: 'パスワードリセット'
+    return_bookmarks: '一覧へ戻る'
     messages:
       require_login: 'ログインしてください'
       delete_confirm: '削除しますか？'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,76 +1,9 @@
-CoverImage.create!(
-  [
-    {
-      image: File.open('./app/assets/images/book28.png'),
-      standard: true
-    },
-    {
-      image: File.open('./app/assets/images/book29.png'),
-      standard: true
-    },
-    {
-      image: File.open('./app/assets/images/book30.png'),
-      standard: true
-    },
-    {
-      image: File.open('./app/assets/images/book31.png'),
-      standard: true
-    },
-    {
-      image: File.open('./app/assets/images/book32.png'),
-      standard: true
-    },
-    {
-      image: File.open('./app/assets/images/book33.png'),
-      standard: true
-    },
-    {
-      image: File.open('./app/assets/images/book34.png'),
-      standard: true
-    },
-    {
-      image: File.open('./app/assets/images/book35.png'),
-      standard: true
-    },
-    {
-      image: File.open('./app/assets/images/book36.png'),
-      standard: true
-    },
-    {
-      image: File.open('./app/assets/images/book19front.png'),
-      standard: false
-    },
-    {
-      image: File.open('./app/assets/images/book20front.png'),
-      standard: false
-    },
-    {
-      image: File.open('./app/assets/images/book21front.png'),
-      standard: false
-    },
-    {
-      image: File.open('./app/assets/images/book22front.png'),
-      standard: false
-    },
-    {
-      image: File.open('./app/assets/images/book23front.png'),
-      standard: false
-    },
-    {
-      image: File.open('./app/assets/images/book24front.png'),
-      standard: false
-    },
-    {
-      image: File.open('./app/assets/images/book25front.png'),
-      standard: false
-    },
-    {
-      image: File.open('./app/assets/images/book26front.png'),
-      standard: false
-    },
-    {
-      image: File.open('./app/assets/images/book27front.png'),
-      standard: false
-    },
-  ]
-)
+tags = Tag.all
+bookmarks = Bookmark.all
+
+bookmarks.each do |bookmark|
+    BookmarkTag.create!(
+      bookmark_id: bookmark.id,
+      tag_id: tags.sample.id
+    )
+  end


### PR DESCRIPTION
## 変更の概要
・ブックマーク一覧部分をabsolute、本棚フレーム画像をstaticで位置づけ
・１ページの表示数を調整
・デモ用のseedデータを用意
・背景画像の変更