### PR TITLE
add:Factorybotを追加。bookmarkモデルのバリデーションを一部編集

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ group :development, :test do
   gem 'faker', '~> 3.2'
   gem 'letter_opener_web', '~> 2.0'
   gem 'rspec-rails', '~> 6.1.5'
+  gem 'factory_bot_rails', '~> 6.5.1'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,11 @@ GEM
     erubi (1.12.0)
     excon (1.3.0)
       logger
+    factory_bot (6.5.6)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.5.1)
+      factory_bot (~> 6.5)
+      railties (>= 6.1.0)
     faker (3.2.3)
       i18n (>= 1.8.11, < 2)
     faraday (2.9.0)
@@ -369,6 +374,7 @@ DEPENDENCIES
   debug
   dockerfile-rails (>= 1.6)
   dotenv-rails (~> 3.1.7)
+  factory_bot_rails (~> 6.5.1)
   faker (~> 3.2)
   fog-aws (~> 3.33)
   gretel (~> 5.0)

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -5,8 +5,8 @@ class Bookmark < ApplicationRecord
   belongs_to :cover_image
 
   validates :url, presence: true, format: /\A#{URI::regexp(%w(http https))}\z/
-  validates :title, length: { maximum: 255 }
-  validates :memo, length: { maximum: 65535 }
+  validates :title, presence: true, length: { maximum: 30 }
+  validates :memo, length: { maximum: 200 }
 
   def self.ransackable_attributes(auth_object = nil)
     ["memo", "title"]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,11 +4,11 @@ class User < ApplicationRecord
   has_many :bookmarks, dependent: :destroy
   has_many :tags, dependent: :destroy
 
-  validates :password, length: { minimum: 6, maximum: 20 }, if: -> { new_record? || changes[:crypted_password] }
+  validates :password, length: { minimum: 8, maximum: 20 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
   validates :reset_password_token, uniqueness: true, allow_nil: true
 
   validates :email, uniqueness: true, presence: true
-  validates :name, presence: true, length: { maximum: 30 }
+  validates :name, presence: true, length: { maximum: 20 }
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,7 +39,6 @@ module Bookmarklibrary
     # Don't generate system test files.
     config.generators do |g|
       g.test_framework :rspec,
-        fixtures: false,
         view_specs: false,
         helper_specs: false,
         routing_specs: false

--- a/db/migrate/20251129072924_change_title_not_null_on_bookmark.rb
+++ b/db/migrate/20251129072924_change_title_not_null_on_bookmark.rb
@@ -1,0 +1,5 @@
+class ChangeTitleNotNullOnBookmark < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :bookmarks, :title, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_02_150444) do
+ActiveRecord::Schema[7.1].define(version: 2025_11_29_072924) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -26,7 +26,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_02_150444) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "title"
+    t.string "title", null: false
     t.string "url", null: false
     t.text "memo"
     t.datetime "created_at", null: false

--- a/spec/factories/bookmarks.rb
+++ b/spec/factories/bookmarks.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :bookmark do
+    sequence(:title) { |n| "Bookmark #{n}" }
+    sequence(:url) { |n| "https://example#{n}" }
+    memo { "test memo" }
+    association :user
+    association :cover_image
+  end
+end

--- a/spec/factories/cover_images.rb
+++ b/spec/factories/cover_images.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :cover_image do
+    image { "abcdefgh" }
+    standard { true }
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :tag do
+    sequence(:name) { |n| "Tag_#{n}" }
+    association :owner
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    name { "Jane" }
+    sequence(:email) { |n| "example_mail#{n}@example.com" }
+    password { "abcdefghijk" }
+    password_confirmation { "abcdefghijk" }
+  end
+end

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe Bookmark, type: :model do
+
+  it "有効なファクトリを持つこと" do
+    expect(FactoryBot.build(:bookmark)).to be_valid
+  end
+
+  it "titleが無ければ無効な状態であること" do
+    bookmark = FactoryBot.build(:bookmark, title: nil)
+    bookmark.valid?
+    expect(bookmark.errors).to be_of_kind(:title, :blank)
+  end
+
+  it "urlが無ければ無効な状態であること" do
+    bookmark = FactoryBot.build(:bookmark, url: nil)
+    bookmark.valid?
+    expect(bookmark.errors).to be_of_kind(:url, :blank)
+  end
+
+  it "urlが適切なフォーマットであれば有効な状態であること" do
+    bookmark = FactoryBot.build(:bookmark, url: 'https://test_example.com')
+    bookmark.valid?
+    expect(bookmark).to be_valid
+  end
+
+  it "urlが適切なフォーマットでなければ無効な状態であること" do
+    bookmark = FactoryBot.build(:bookmark, url: 'httpexample.com')
+    bookmark.valid?
+    expect(bookmark.errors).to be_of_kind(:url, :invalid)
+  end
+
+  it "titleの文字数が30文字の場合は有効な状態であること" do
+    bookmark = FactoryBot.build(:bookmark, title: 'a'* 30)
+    bookmark.valid?
+    expect(bookmark).to be_valid
+  end
+
+  it "titleの文字数が31文字の場合は無効な状態であること" do
+    bookmark = FactoryBot.build(:bookmark, title: 'a'* 31)
+    bookmark.valid?
+    expect(bookmark.errors).to be_of_kind(:title, :too_long)
+  end
+
+  it "memoの文字数が200文字の場合は有効な状態であること" do
+    bookmark = FactoryBot.build(:bookmark, memo: 'a'* 200)
+    bookmark.valid?
+    expect(bookmark).to be_valid
+  end
+
+  it "memoの文字数が201文字の場合は無効な状態であること" do
+    bookmark = FactoryBot.build(:bookmark, memo: 'a'* 201)
+    bookmark.valid?
+    expect(bookmark.errors).to be_of_kind(:memo, :too_long)
+  end
+
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,41 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe Tag, type: :model do
-  #名前があれば有効な状態であること
-  it "is valid with name" do
-    user = User.create(
-      name: 'Jane',
-      email: 'example_mail@example.com',
-      password: 'abcdefghijk',
-      password_confirmation: 'abcdefghijk'
-    )
+
+  it "名前があれば有効な状態であること" do
+    user = FactoryBot.create(:user)
     tag = user.tags.build(
       name: 'Tag name',
     )
     expect(tag).to be_valid
   end
 
-  #名前がなければ無効な状態であること
-  it "is invalid without a name" do
-    user = User.create(
-      name: 'Jane',
-      email: 'example_mail@example.com',
-      password: 'abcdefghijk',
-      password_confirmation: 'abcdefghijk'
-    )
+  it "名前がなければ無効な状態であること" do
+    user = FactoryBot.create(:user)
     tag = user.tags.build(name: nil)
     tag.valid?
-    expect(tag.errors[:name]).to include("を入力してください")
+    expect(tag.errors).to be_of_kind(:name, :blank)
   end
 
-  #ユーザー単位では同じタグ名を許可しないこと
-  it "does not allow duplicate tag names per user" do
-    user = User.create(
-      name: 'Jane',
-      email: 'example_mail@example.com',
-      password: 'abcdefghijk',
-      password_confirmation: 'abcdefghijk'
-    )
+  it "ユーザー単位では同じタグ名を許可しないこと" do
+    user = FactoryBot.create(:user)
     user.tags.create(
       name: 'Test tag',
     )
@@ -43,8 +26,24 @@ RSpec.describe Tag, type: :model do
       name: 'Test tag',
     )
     new_tag.valid?
-    expect(new_tag.errors[:name]).to include("はすでに存在します")
+    expect(new_tag.errors).to be_of_kind(:name, :taken)
   end
 
-#二人のユーザーが同じタグの名前を使うことは許可すること
+  it "二人のユーザーが同じタグの名前を使うことは許可すること" do
+    user = FactoryBot.create(
+      :user,
+      email: 'test_001@example.com',
+    )
+    user.tags.create(
+      name: 'Test tag',
+    )
+    other_user = FactoryBot.create(
+      :user,
+      email: 'test_002@example.com',
+    )
+    other_tag = other_user.tags.build(
+      name: 'Test tag',
+    )
+    expect(other_tag).to be_valid
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,8 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  # 名前、メール、パスワード、パスワード(確認)があれば有効な状態であること
-  it "is valid with a name, email, password, and password_confirmation" do
+
+  it "有効なファクトリを持つこと" do
+    expect(FactoryBot.build(:user)).to be_valid
+  end
+
+  it "名前、メール、パスワード、パスワード(確認)があれば有効な状態であること" do
     user = User.new(
     name: 'Jane',
     email: 'example_mail@example.com',
@@ -12,33 +16,94 @@ RSpec.describe User, type: :model do
     expect(user).to be_valid
   end
 
-  # 名がなければ無効な状態であること
-  it "is invalid without a name" do
-    user = User.new(name: nil)
+  it "名がなければ無効な状態であること" do
+    user = FactoryBot.build(:user, name: nil)
     user.valid?
-    expect(user.errors[:name]).to include("を入力してください")
+    expect(user.errors).to be_of_kind(:name, :blank)
   end
-  # メールアドレスがなければ無効な状態であること
-  it "is invalid without an email address" do
-    user = User.new(email: nil)
+
+  it "メールアドレスがなければ無効な状態であること" do
+    user = FactoryBot.build(:user, email: nil)
     user.valid?
-    expect(user.errors[:email]).to include("を入力してください")
+    expect(user.errors).to be_of_kind(:email, :blank)
   end
-  # 重複したメールアドレスなら無効な状態であること
-  it "is invalid with a duplicate email address" do
-    User.create(
-      name: 'Jane',
-      email: 'example_mail@example.com',
-      password: 'abcdefghijk',
-      password_confirmation: 'abcdefghijk'
-    )
-    user = User.new(
-      name: 'Mary',
-      email: 'example_mail@example.com',
-      password: 'abcdefghijk',
-      password_confirmation: 'abcdefghijk'
+
+  it "重複したメールアドレスなら無効な状態であること" do
+    FactoryBot.create(:user, email: 'example_mail@example.com')
+    user = FactoryBot.build(:user, email: 'example_mail@example.com')
+    user.valid?
+    expect(user.errors).to be_of_kind(:email, :taken)
+  end
+
+  it "名前が20文字の場合は有効な状態であること" do
+    user = FactoryBot.build(:user, name: 'a'* 20)
+    user.valid?
+    expect(user).to be_valid
+  end
+
+  it "名前が21文字の場合は無効な状態であること" do
+    user = FactoryBot.build(:user, name: 'a'* 21)
+    user.valid?
+    expect(user.errors).to be_of_kind(:name, :too_long)
+  end
+
+  it "パスワードが8文字の場合は有効な状態であること" do
+    user = FactoryBot.build(
+      :user,
+      password: 'a'* 8,
+      password_confirmation: 'a'* 8
+      )
+    user.valid?
+    expect(user).to be_valid
+  end
+
+  it "パスワードが7文字の場合は無効な状態であること" do
+    user = FactoryBot.build(
+      :user,
+      password: 'a'* 7,
+      password_confirmation: 'a'* 7
+      )
+    user.valid?
+    expect(user.errors).to be_of_kind(:password, :too_short)
+  end
+
+  it "パスワードが20文字の場合は有効な状態であること" do
+    user = FactoryBot.build(
+      :user,
+      password: 'a'* 20,
+      password_confirmation: 'a'* 20
+      )
+    user.valid?
+    expect(user).to be_valid
+  end
+
+  it "パスワードが21文字の場合は無効な状態であること" do
+    user = FactoryBot.build(
+      :user,
+      password: 'a'* 21,
+      password_confirmation: 'a'* 21
+      )
+    user.valid?
+    expect(user.errors).to be_of_kind(:password, :too_long)
+  end
+
+  it "パスワード(確認)がパスワードと一致していれば有効な状態であること" do
+    user = FactoryBot.build(
+      :user,
+      password: '12345678',
+      password_confirmation: '12345678'
+      )
+    user.valid?
+    expect(user).to be_valid
+  end
+
+  it "パスワード(確認)がパスワードと一致していなければ無効な状態であること" do
+    user = FactoryBot.build(
+    :user,
+    password: '12345678',
+    password_confirmation: 'abcdefgh',
     )
     user.valid?
-    expect(user.errors[:email]).to include("はすでに存在します")
+    expect(user.errors).to be_of_kind(:password_confirmation, :confirmation)
   end
 end


### PR DESCRIPTION
## 変更の概要
・FactoryBotのgemを追加
・bookmarkのモデルテストまで実装
・その過程でbookmarkモデルのバリデーションの内容を一部見直し


## やったことの詳細
・bookmarkモデルのtitleカラムにnil: falseを追加し、
後に検索から再アクセスするためのキーワードの設定し忘れを防ぐ。
・titleの文字数を30文字まで、memoの文字数を200文字までに見直し。
