### PR TITLE
add: controllerテストの実装

### DIFF
--- a/spec/controllers/static_pages_controller_spec.rb
+++ b/spec/controllers/static_pages_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe StaticPagesController, type: :controller do
+
+  describe "#top" do
+    it "正常にレスポンスを返すこと" do
+      get :top
+      expect(response).to be_successful
+    end
+
+    it "200レスポンスを返すこと" do
+      get :top
+      expect(response).to have_http_status "200"
+    end
+  end
+end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe TagsController, type: :controller do
+  describe "#index" do
+
+    context "ログイン済みユーザー" do
+      before do
+        @user = FactoryBot.create(:user)
+      end
+
+      it "正常にレスポンスを返すこと" do
+        login_user(@user)
+        get :index
+        expect(response).to be_successful
+      end
+
+      it "200レスポンスを返すこと" do
+        login_user(@user)
+        get :index
+        expect(response).to have_http_status "200"
+      end
+    end
+
+    context "ゲストユーザー" do
+      it "302レスポンスを返すこと" do
+        get :index
+        expect(response).to have_http_status "302"
+      end
+
+      it "ログイン画面にリダイレクトすること" do
+        get :index
+        expect(response).to redirect_to login_path
+      end
+    end
+  end
+
+  describe "#show" do
+    context "タグ作成ユーザー" do
+      before do
+        @user = FactoryBot.create(:user)
+        @tag = FactoryBot.create(:tag, user: @user)
+      end
+
+      it "正常にレスポンスを返すこと" do
+        login_user(@user)
+        get :show, params: { id: @tag.id }
+        expect(response).to be_successful
+      end
+    end
+
+    context "タグ作成者ではないユーザー" do
+      before do
+        @user = FactoryBot.create(:user)
+        other_user = FactoryBot.create(:user)
+        @tag = FactoryBot.create(:tag, user: other_user)
+      end
+
+      it "ActiveRecord::RecordNotFound を返すこと" do
+        login_user(@user)
+        expect{
+          get :show, params: { id: @tag.id }
+      }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :tag do
     sequence(:name) { |n| "Tag_#{n}" }
-    association :owner
+    association :user
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,4 +62,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include Sorcery::TestHelpers::Rails::Controller, type: :controller
 end


### PR DESCRIPTION
## 変更の概要
トップページとtagページにコントローラーテストを実装

## 備考
現在はあまり使われていないテストのようなので学習の一環として部分的に留める。
必要そうならまた改めて追加する。